### PR TITLE
Changed CalendarDateTime to convert to UTC on construction.

### DIFF
--- a/src/ChargerAstronomyShared/Domain/CalendarDateTime.cs
+++ b/src/ChargerAstronomyShared/Domain/CalendarDateTime.cs
@@ -33,15 +33,18 @@ namespace ChargerAstronomyShared.Domain
 
         /// <summary>The real-valued second in the half-open range [0, 60).</summary>
         public double second;
-
+        
         public CalendarDateTime(int year, int month, int day, int hour, int minute, double second)
         {
+            var offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).TotalHours;
             this.year = year;
             this.month = month;
             this.day = day;
-            this.hour = hour;
+            this.hour = hour - (int)offset;
             this.minute = minute;
             this.second = second;
+            
+
         }
 
         /// <summary>Convert a J2000 day value to a Gregorian calendar date.</summary>
@@ -50,7 +53,6 @@ namespace ChargerAstronomyShared.Domain
         {
             // Adapted from the NOVAS C 3.1 function cal_date().
             // Convert fractional days since J2000 into Gregorian calendar date/time.
-
             double djd = ut + 2451545.5;
             long jd = (long)Math.Floor(djd);
             double x = 24.0 * (djd % 1.0);


### PR DESCRIPTION
The AstoTime object expects the CalendarDateTime to be of type UTC. This change adds the current users UTC offset to the time that is passed. This is not entirely correct, since the location that the user is passing is not necessarily in their time zone, but significantly more complex logic would be required to make that distinction (most likely an API call to get the time zone for specific date/time/location). 